### PR TITLE
Save Evaluator Output to User-Specified Directory

### DIFF
--- a/evaluator/README.md
+++ b/evaluator/README.md
@@ -45,6 +45,7 @@ python src/main.py \
     --patch <path-to-patch-file> \
     --contract-file <contract-from-dataset> \
     --main-contract <contract-name>
+    --output <output-directory>
 ```
 
 ### Required Arguments
@@ -53,6 +54,7 @@ python src/main.py \
 - `--patch`: Path to the patch file that will be evaluated
 - `--contract-file`: Contract in `smartbugs-curated/0.4.x/contracts/dataset`. Required format `<vulnerability-type>/<filename>`.
 - `--main-contract`: Name of the main contract to be patched
+- `--output`: Path to output directory to store results. Default: `./results`
 
 ### Example
 
@@ -87,7 +89,14 @@ Exploit Test Failures (1):
 - Exploit file: reentrancy/reentrancy_simple_test.js
   Contract File: reentrancy/reentrancy_simple.sol
   Error: Transaction reverted without a reason string
+
+Results saved in /sb-heist/evaluator/results/20250520_101154
 ```
+
+In the `results/20250520_101154` you will find the following:
+- `hardhat_error.txt`: Warnings and errors from hardhat compilation and testing processes.
+- `hardhat_output.txt`: Standard output of hardhat reporter.
+- `test-results.json`: json file with test results.
 
 ## Development
 

--- a/evaluator/src/core/patch_evaluator.py
+++ b/evaluator/src/core/patch_evaluator.py
@@ -8,7 +8,7 @@ import os
 import logging
 
 class PatchEvaluator:
-    def __init__(self, base_directory: str):
+    def __init__(self, base_directory: str, results_directory: str):
         self.file_manager = FileManager(base_directory)
         self.dataset_dir = os.path.abspath(os.path.join(base_directory, "contracts", "dataset")).replace(os.sep, '/')
         self.dataset_files = []
@@ -18,7 +18,8 @@ class PatchEvaluator:
                     parent_dir = os.path.basename(root)
                     self.dataset_files.append(os.path.join(parent_dir, file).replace(os.sep, '/'))
         self.patch_factory = PatchStrategyFactory()
-        self.test_runner = HardhatTestRunner(base_directory)
+        self.test_runner = HardhatTestRunner(base_directory, results_directory)
+        self.results_directory = results_directory
         self.logger = logging.getLogger(__name__)
 
     def evaluate_patch(self, patch: Patch) -> TestResult:

--- a/smartbugs-curated/0.8.x/scripts/CustomReporter.js
+++ b/smartbugs-curated/0.8.x/scripts/CustomReporter.js
@@ -102,7 +102,6 @@ class CustomReporter extends Spec {
             // Write to JSON file
             const jsonPath = path.join(__dirname, 'test-results.json');
             fs.writeFileSync(jsonPath, JSON.stringify(results, null, 2));
-            console.log(`\nTest results written to ${jsonPath}`);
         }
     });
   }


### PR DESCRIPTION
Updates the evaluator to write all output files (e.g. results.json, errors, warnings) to a user-specified directory.

Changes:
- Added CLI argument to specify output directory.
- Defaults to evaluator/results/ if none is provided.
- Redirected all outputs (including results.json, error/warning logs) to the specified directory.

closes #57 